### PR TITLE
Arbitrary framework packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Build apptainer containers for OpenFOAM-based projects
+# Build apptainer containers for your projects
 
 <p align="center">
 <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/FoamScience/openfoam-apptainer-packaging/ci.yaml?style=for-the-badge&logo=linuxcontainers&label=Test%20container">
@@ -7,7 +7,7 @@
 <img alt="Foam Extend" src="https://img.shields.io/badge/Foam_Extend-teal?style=for-the-badge">
 </p>
 
-This is a project to automate the building of HPC-ready containers for OpenFOAM-based projects
+This is a project to automate building HPC-ready containers (originally for OpenFOAM-based projects)
 using `apptainer`.
 
 > [!NOTE]
@@ -24,10 +24,17 @@ using `apptainer`.
 
 Automated workflows to:
 
-- Build a base `OpenFOAM` container (supporting various forks and versions) to run on HPCs
+- Build a base framework (eg: `OpenFOAM`) container (supporting various forks and versions) to run on HPCs
 - Build project-specific containers that inherit from a target base container
 - OpenMPI is a first-class citizen: `mpirun -n 16 apptainer run container.sif "solver -parallel"`
   should 'just work'.
+
+## Highlighted features
+
+1. Automated, configuration-only workflows to produce containers that behave similarly across frameworks.
+1. A JSON Database of container metadata, with full control at the hands of the container maintainer.
+1. Maintaining definition files for your projects can be done in your own repos.
+1. Loading your own repositories of base framework container definitions works seamlessly.
 
 ## Quick Instructions
 
@@ -40,7 +47,8 @@ ansible-playbook build.yaml --extra-vars "original_dir=$PWD" --extra-vars "@conf
 
 > [!TIP]
 > `ansible` is a nice tool to automate builds and make sure your host system has the required
-> dependencies to be able to build the containers.
+> dependencies to be able to build the containers. The configuration file and base definitions
+> provided serve as examples to build OpenFOAM containers.
 
 The ansible command (by default) will:
 - Create the following tree in the current working folder:
@@ -48,15 +56,15 @@ The ansible command (by default) will:
 containers/
 ├── basic
 │   ├── opencfd-openfoam.sif
-│   └── ubuntu-24.04-ompi-4.1.5.sif
+│   └── ubuntu-24.04-openmpi-4.1.5.sif
 └── projects
     └── test-master.sif
 ```
-- Build a basic OpenMPI container `containers/basic/ubuntu-24.04-ompi-4.1.5.sif`, or pull
-  it from [ghcr.io](https://ghcr.io) if possible
+- Build a basic OpenMPI container `containers/basic/ubuntu-24.04-openmpi-4.1.5.sif`, or
+  pull it from [ghcr.io](https://ghcr.io) if possible
 - Build a base (OpenCFD) OpenFOAM container `containers/basic/opencfd-openfoam.sif`, or
   pull it from [ghcr.io](https://ghcr.io) if possible
-- Build a test project container, to make sure MPI works alright
+- Build a test project container, to make sure MPI works alright in OpenFOAM containers
 
 Check the [docs.md](docs.md) for details on how the configuration file
 is expected to be structured.
@@ -69,22 +77,22 @@ sequenceDiagram
   participant GHCR
   participant Docker Hub
   participant Local Build
-  participant OpenMPI Container
-  participant OpenFOAM Container
+  participant MPI Container
+  participant Framework Container
   participant Project Container
 
   User->>Ansible Playbook: Start playbook with config.yaml
-  Ansible Playbook->>GHCR: Check if OpenMPI Container exists
-  GHCR-->>Ansible Playbook: OpenMPI Container not found
+  Ansible Playbook->>GHCR: Check if MPI Container exists
+  GHCR-->>Ansible Playbook: MPI Container not found
   Ansible Playbook->>Docker Hub: Pull Ubuntu image
   Docker Hub-->>Ansible Playbook: Ubuntu image pulled
-  Ansible Playbook->>Local Build: Build OpenMPI Container on top of Ubuntu image
-  Local Build-->>OpenMPI Container: OpenMPI Container created
-  Ansible Playbook->>GHCR: Check if OpenFOAM Container exists
-  GHCR-->>Ansible Playbook: OpenFOAM Container not found
-  Ansible Playbook->>Local Build: Build OpenFOAM Container on top of OpenMPI Container
-  Local Build-->>OpenFOAM Container: OpenFOAM Container created
-  Ansible Playbook->>Local Build: Build Project Container on top of OpenFOAM Container with build args
+  Ansible Playbook->>Local Build: Build MPI Container on top of Ubuntu image
+  Local Build-->>MPI Container: MPI Container created
+  Ansible Playbook->>GHCR: Check if Framework Container exists
+  GHCR-->>Ansible Playbook: Framework Container not found
+  Ansible Playbook->>Local Build: Build Framework Container on top of MPI Container
+  Local Build-->>Framework Container: Framework Container created
+  Ansible Playbook->>Local Build: Build Project Container on top of Framework Container with build args
   Local Build-->>Project Container: Project Container created
   Project Container-->>User: Container ready for use
 ```

--- a/basic/com-openfoam.def
+++ b/basic/com-openfoam.def
@@ -10,43 +10,44 @@
 #
 # ---------------------------------------------------------------------------
 Bootstrap: localimage
-From: containers/basic/ubuntu-{{ OS_VERSION }}-ompi-{{ OPENMPI_VERSION }}.sif
+From: containers/basic/{{ OS_DISTRO }}-{{ OS_VERSION }}-{{MPI_IMPLEMENTATION}}-{{ MPI_VERSION }}.sif
 
 %arguments
+    OS_DISTRO=ubuntu
     OS_VERSION=24.04
-    OPENMPI_VERSION=4.1.5
-    OPENFOAM_VERSION=2312
-    OPENFOAM_GIT_REF=default
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
+    FRAMEWORK_VERSION=2312
+    FRAMEWORK_GIT_REF=default
 
 %post
     curl https://dl.openfoam.com/add-debian-repo.sh | bash
     DEBIAN_FRONTEND=noninteractive
-    apt-get -y install --no-install-recommends openfoam{{ OPENFOAM_VERSION }}-dev python3
-    dpkg --remove --force-depends libopenmpi-dev openmpi-bin openmpi-common
-    jq --arg app openfoam --arg commit {{ OPENFOAM_GIT_REF }} \
-        --arg branch {{ OPENFOAM_GIT_REF }} \
+    apt-get -y install --no-install-recommends openfoam{{ FRAMEWORK_VERSION }}-dev python3
+    jq --arg app openfoam --arg commit {{ FRAMEWORK_GIT_REF }} \
+        --arg branch {{ FRAMEWORK_GIT_REF }} \
         '.[$app] |= if . == null then
         {
             fork: "com-openfoam",
             branch: $branch,
             commit: $commit,
-            version: "{{ OPENFOAM_VERSION }}"
+            version: "{{ FRAMEWORK_VERSION }}"
         }
         else . +
         {
             fork: "com-openfoam",
             branch: $branch,
             commit: $commit,
-            version: "{{ OPENFOAM_VERSION }}"
+            version: "{{ FRAMEWORK_VERSION }}"
         } end' /apps.json > /tmp/apps.json
     mv /tmp/apps.json /apps.json
 
 %runscript
-    /bin/bash -c 'cd /usr/lib/openfoam/openfoam{{ OPENFOAM_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
+    /bin/bash -c 'cd /usr/lib/openfoam/openfoam{{ FRAMEWORK_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
     if [ $# -eq 0 ]; then
-        /usr/bin/openfoam{{ OPENFOAM_VERSION }}
+        /usr/bin/openfoam{{ FRAMEWORK_VERSION }}
     else
-        /usr/bin/openfoam{{ OPENFOAM_VERSION }} $@
+        /usr/bin/openfoam{{ FRAMEWORK_VERSION }} $@
     fi
 
 %labels

--- a/basic/foam-extend.def
+++ b/basic/foam-extend.def
@@ -10,13 +10,15 @@
 #
 # ---------------------------------------------------------------------------
 Bootstrap: localimage
-From: containers/basic/ubuntu-{{ OS_VERSION }}-ompi-{{ OPENMPI_VERSION }}.sif
+From: containers/basic/{{ OS_DISTRO }}-{{ OS_VERSION }}-{{ MPI_IMPLEMENTATION }}-{{ MPI_VERSION }}.sif
 
 %arguments
+    OS_DISTRO=ubuntu
     OS_VERSION=24.04
-    OPENMPI_VERSION=4.1.5
-    OPENFOAM_VERSION=5.0
-    OPENFOAM_GIT_REF=master
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
+    FRAMEWORK_VERSION=5.0
+    FRAMEWORK_GIT_REF=master
 
 %post
     DEBIAN_FRONTEND=noninteractive
@@ -26,38 +28,38 @@ From: containers/basic/ubuntu-{{ OS_VERSION }}-ompi-{{ OPENMPI_VERSION }}.sif
         python3 libpython3-dev libxt-dev rpm mercurial apt-utils\
         patch libmetis-dev libscotch-dev libparmetis-dev
     mkdir -p /opt/foam
-    git clone --single-branch --branch {{ OPENFOAM_GIT_REF }} --depth 1 \
-        git://git.code.sf.net/p/foam-extend/foam-extend-{{ OPENFOAM_VERSION }} \
-        /opt/foam/foam-extend-{{ OPENFOAM_VERSION }}
-    sed -i 's|^foamInstall.*|foamInstall=/opt/foam|' /opt/foam/foam-extend-{{ OPENFOAM_VERSION }}/etc/bashrc
+    git clone --single-branch --branch {{ FRAMEWORK_GIT_REF }} --depth 1 \
+        git://git.code.sf.net/p/foam-extend/foam-extend-{{ FRAMEWORK_VERSION }} \
+        /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }}
+    sed -i 's|^foamInstall.*|foamInstall=/opt/foam|' /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }}/etc/bashrc
     nProcs=$(nproc)
-    /bin/bash -c "cd /opt/foam/foam-extend-{{ OPENFOAM_VERSION }} && source etc/bashrc && ./Allwmake.firstInstall -j $nProcs"
-    rm -rf /opt/foam/foam-extend-{{ OPENFOAM_VERSION }}/tutorials/*
-    OPENFOAM_COMMIT_HASH=$(git -C /opt/foam/foam-extend-{{ OF_VERSION }} rev-parse HEAD)
-    jq --arg app openfoam --arg commit $OPENFOAM_COMMIT_HASH \
-        --arg branch {{ OPENFOAM_GIT_REF }} \
+    /bin/bash -c "cd /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }} && source etc/bashrc && ./Allwmake.firstInstall -j $nProcs"
+    rm -rf /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }}/tutorials/*
+    FRAMEWORK_COMMIT_HASH=$(git -C /opt/foam/foam-extend-{{ OF_VERSION }} rev-parse HEAD)
+    jq --arg app openfoam --arg commit $FRAMEWORK_COMMIT_HASH \
+        --arg branch {{ FRAMEWORK_GIT_REF }} \
         '.[$app] |= if . == null then
         {
             fork: "foam-extend",
             branch: $branch,
             commit: $commit,
-            version: "{{ OPENFOAM_VERSION }}"
+            version: "{{ FRAMEWORK_VERSION }}"
         }
         else . +
         {
             fork: "foam-extend",
             branch: $branch,
             commit: $commit,
-            version: "{{ OPENFOAM_VERSION }}"
+            version: "{{ FRAMEWORK_VERSION }}"
         } end' /apps.json > /tmp/apps.json
     mv /tmp/apps.json /apps.json
 
 %runscript
-    /bin/bash -c 'cd /opt/foam/foam-extend-{{ OPENFOAM_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
+    /bin/bash -c 'cd /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
     if [ $# -eq 0 ]; then
-        /bin/bash -c "source /opt/foam/foam-extend-{{ OPENFOAM_VERSION }}/etc/bashrc && /bin/bash --login"
+        /bin/bash -c "source /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }}/etc/bashrc && /bin/bash --login"
     else
-        /bin/bash -c "source /opt/foam/foam-extend-{{ OPENFOAM_VERSION }}/etc/bashrc && $@"
+        /bin/bash -c "source /opt/foam/foam-extend-{{ FRAMEWORK_VERSION }}/etc/bashrc && $@"
     fi
 
 %labels

--- a/basic/lammps.def
+++ b/basic/lammps.def
@@ -1,0 +1,67 @@
+# ---------------------------------------------------------------------------
+#
+# Create Ubuntu-based LAMMPS image
+#
+# Build
+#   apptainer build lpm.sif lammps.def
+#
+# Note
+#   apptainer version 1.3.1
+#
+# ---------------------------------------------------------------------------
+Bootstrap: localimage
+From: containers/basic/{{ OS_DISTRO }}-{{ OS_VERSION }}-{{MPI_IMPLEMENTATION}}-{{ MPI_VERSION }}.sif
+
+%arguments
+    OS_DISTRO=ubuntu
+    OS_VERSION=24.04
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
+    FRAMEWORK_VERSION=patch_27Jun2024
+    FRAMEWORK_GIT_REF=patch_27Jun2024
+
+%post
+    DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get -y install --no-install-recommends cmake
+    git clone -b {{ FRAMEWORK_VERSION }} https://github.com/lammps/lammps.git /opt/lammps
+    cd /opt/lammps
+    commit=$(git rev-parse HEAD)
+    mkdir build
+    cd build
+    cmake ../cmake
+    cmake --build .
+    make install PREFIX=/usr/local
+    curl -o /etc/apt/trusted.gpg.d/openfoam.asc https://dl.openfoam.org/gpg.key
+    jq --arg app lammps --arg commit $commit \
+        --arg release {{ FRAMEWORK_GIT_REF }} \
+        '.[$app] |= if . == null then
+        {
+            fork: "lammps",
+            release: $release,
+            commit: $commit,
+            version: "{{ FRAMEWORK_VERSION }}"
+        }
+        else . +
+        {
+            fork: "lammps",
+            release: $release,
+            commit: $commit,
+            version: "{{ FRAMEWORK_VERSION }}"
+        } end' /apps.json > /tmp/apps.json
+    mv /tmp/apps.json /apps.json
+
+%environment
+    export PATH="/usr/local/bin:${PATH}"
+    export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+
+%runscript
+    if [ $# -eq 0 ]; then
+        /bin/bash -c "/bin/bash --login"
+    else
+        /bin/bash -c "$@"
+    fi
+
+%labels
+    Maintainer Mohammed Elwardi Fadeli
+    Description Ubuntu-based OpenFOAM (Foundation version) image with OpenMPI

--- a/basic/openmpi.def
+++ b/basic/openmpi.def
@@ -10,35 +10,37 @@
 #
 # ---------------------------------------------------------------------------
 Bootstrap: docker
-From: ubuntu:{{ OS_VERSION }}
+From: {{ OS_DISTRO }}:{{ OS_VERSION }}
 
 %arguments
+    OS_DISTRO=ubuntu
     OS_VERSION=24.04
-    OPENMPI_VERSION=4.1.5
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
 
 %post
     DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get -y install --no-install-recommends \
         curl gcc g++ gfortran make file jq ca-certificates bzip2 git
-    export OPENMPI_VERSION={{ OPENMPI_VERSION }}
-    ompi_short=$(echo {{ OPENMPI_VERSION }} | cut -d '.' -f1-2)
-    export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v$ompi_short/openmpi-{{ OPENMPI_VERSION }}.tar.bz2"
+    export MPI_VERSION={{ MPI_VERSION }}
+    ompi_short=$(echo {{ MPI_VERSION }} | cut -d '.' -f1-2)
+    export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v$ompi_short/openmpi-{{ MPI_VERSION }}.tar.bz2"
     export OMPI_DIR=/opt/ompi
     mkdir -p $OMPI_DIR /tmp/ompi
-    cd /tmp/ompi && curl -O $OMPI_URL && tar -xjf openmpi-$OPENMPI_VERSION.tar.bz2
-    cd /tmp/ompi/openmpi-$OPENMPI_VERSION && ./configure --prefix=$OMPI_DIR && make -j$(nproc) install
+    cd /tmp/ompi && curl -O $OMPI_URL && tar -xjf openmpi-$MPI_VERSION.tar.bz2
+    cd /tmp/ompi/openmpi-$MPI_VERSION && ./configure --prefix=$OMPI_DIR && make -j$(nproc) install
     export PATH=$OMPI_DIR/bin:$PATH
     export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
     echo '{}' > /apps.json
     jq --arg app openmpi \
         '.[$app] |= if . == null then
         {
-            version: "{{ OPENMPI_VERSION }}"
+            version: "{{ MPI_VERSION }}"
         }
         else . +
         {
-            version: "{{ OPENMPI_VERSION }}"
+            version: "{{ MPI_VERSION }}"
         } end' /apps.json > /tmp/apps.json
     mv /tmp/apps.json /apps.json
 

--- a/basic/org-openfoam.def
+++ b/basic/org-openfoam.def
@@ -10,13 +10,15 @@
 #
 # ---------------------------------------------------------------------------
 Bootstrap: localimage
-From: containers/basic/ubuntu-{{ OS_VERSION }}-ompi-{{ OPENMPI_VERSION }}.sif
+From: containers/basic/{{ OS_DISTRO }}-{{ OS_VERSION }}-{{MPI_IMPLEMENTATION}}-{{ MPI_VERSION }}.sif
 
 %arguments
+    OS_DISTRO=ubuntu
     OS_VERSION=24.04
-    OPENMPI_VERSION=4.1.5
-    OPENFOAM_VERSION=11
-    OPENFOAM_GIT_REF=default
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
+    FRAMEWORK_VERSION=11
+    FRAMEWORK_GIT_REF=default
 
 %post
     curl -o /etc/apt/trusted.gpg.d/openfoam.asc https://dl.openfoam.org/gpg.key
@@ -25,32 +27,31 @@ From: containers/basic/ubuntu-{{ OS_VERSION }}-ompi-{{ OPENMPI_VERSION }}.sif
     apt-get -y install --no-install-recommends software-properties-common
     add-apt-repository http://dl.openfoam.org/ubuntu
     apt-get update
-    apt-get -y install --no-install-recommends openfoam{{ OPENFOAM_VERSION }}
-    rm -rf /opt/openfoam{{ OPENFOAM_VERSION }}/tutorials/*
-    dpkg --remove --force-depends libopenmpi-dev openmpi-bin openmpi-common
-    jq --arg app openfoam --arg commit {{ OPENFOAM_GIT_REF }} \
-        --arg branch {{ OPENFOAM_GIT_REF }} \
+    apt-get -y install --no-install-recommends openfoam{{ FRAMEWORK_VERSION }}
+    rm -rf /opt/openfoam{{ FRAMEWORK_VERSION }}/tutorials/*
+    jq --arg app openfoam --arg commit {{ FRAMEWORK_GIT_REF }} \
+        --arg branch {{ FRAMEWORK_GIT_REF }} \
         '.[$app] |= if . == null then
         {
             fork: "org-openfoam",
             branch: $branch,
             commit: $commit,
-            version: "{{ OPENFOAM_VERSION }}"
+            version: "{{ FRAMEWORK_VERSION }}"
         }
         else . +
         {
             fork: "org-openfoam",
             branch: $branch,
             commit: $commit,
-            version: "{{ OPENFOAM_VERSION }}"
+            version: "{{ FRAMEWORK_VERSION }}"
         } end' /apps.json > /tmp/apps.json
 
 %runscript
-    /bin/bash -c 'cd /opt/openfoam{{ OPENFOAM_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
+    /bin/bash -c 'cd /opt/openfoam{{ FRAMEWORK_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
     if [ $# -eq 0 ]; then
-        /bin/bash -c "source /opt/openfoam{{ OPENFOAM_VERSION }}/etc/bashrc && /bin/bash --login"
+        /bin/bash -c "source /opt/openfoam{{ FRAMEWORK_VERSION }}/etc/bashrc && /bin/bash --login"
     else
-        /bin/bash -c "source /opt/openfoam{{ OPENFOAM_VERSION }}/etc/bashrc && $@"
+        /bin/bash -c "source /opt/openfoam{{ FRAMEWORK_VERSION }}/etc/bashrc && $@"
     fi
 
 %labels

--- a/build.yaml
+++ b/build.yaml
@@ -15,7 +15,7 @@
       assert:
         that:
           - apptainer_version_output.stdout.split(' ')[2] is version("1.3.1", ">=")
-        fail_msg: "Apptainer version is not 1.3.1 or later"
+        fail_msg: "Supported apptainer versions are 1.3.1 or newer"
     - name: Basic containers folder check
       file:
         path: "{{ original_dir }}/containers/basic"
@@ -35,6 +35,10 @@
     - name: Set default pull configuration
       set_fact:
         pull: "{{ pull | default({'try_to_pull': true, 'protocol': 'oras', 'scope': 'ghcr.io/foamscience'}) }}"
+    - name: Process extra basic definitions
+      include_tasks:
+        file: "{{ playbook_dir }}/partials/include_extra_basics.yaml"
+      when: containers.extra_basics is defined
 
 - name: Base containers
   hosts: "{{ groups['build_hosts'] | default('localhost') }}"
@@ -46,25 +50,29 @@
       loop: "{{ containers.basic.items() }}"
     - name: Try to get MPI containers from registry
       shell: |
-        if [ ! -f {{ original_dir }}/containers/basic/ubuntu-{{ item.os.version }}-ompi-{{ item.mpi.version }}.sif ]; then
+        if [ ! -f {{ original_dir }}/containers/basic/{{ item.os.distro }}-{{ item.os.version }}-{{ item.mpi.implementation }}-{{ item.mpi.version }}.sif ]; then
           apptainer pull \
-            {{ original_dir }}/containers/basic/ubuntu-{{ item.os.version }}-ompi-{{ item.mpi.version }}.sif \
-            {{ pull.protocol }}://{{ pull.scope }}/ubuntu-{{ item.os.version }}-ompi-{{ item.mpi.version }}
+            {{ original_dir }}/containers/basic/{{ item.os.distro }}-{{ item.os.version }}-{{ item.mpi.implementation }}-{{ item.mpi.version }}.sif \
+            {{ pull.protocol }}://{{ pull.scope }}/{{ item.os.distro }}-{{ item.os.version }}-{{ item.mpi.implementation }}-{{ item.mpi.version }}
         fi
       loop: "{{ mpi_containers }}"
       ignore_errors: yes
       when: pull.try_to_pull
-    - name: Build OMPI base containers if .sif file doesn't exist
+    - name: Build MPI base containers if .sif file doesn't exist
+      vars:
+        distro: "{{ item.os.distro | regex_replace('_', '/') }}"
       shell: |
-        if [ ! -f {{ original_dir }}/containers/basic/ubuntu-{{ item.os.version }}-ompi-{{ item.mpi.version }}.sif ]; then
+        if [ ! -f {{ original_dir }}/containers/basic/{{ item.os.distro }}-{{ item.os.version }}-{{ item.mpi.implementation }}-{{ item.mpi.version }}.sif ]; then
           apptainer build \
             --warn-unused-build-args \
+            --build-arg OS_DISTRO={{ distro }} \
             --build-arg OS_VERSION={{ item.os.version }} \
+            --build-arg MPI_IMPLEMENTATION={{ item.mpi.implementation }} \
             --build-arg MPI_VERSION={{ item.mpi.version }} \
-            {{ original_dir }}/containers/basic/ubuntu-{{ item.os.version }}-ompi-{{ item.mpi.version }}.sif \
-            {{ playbook_dir }}/basic/openmpi.def
+            {{ original_dir }}/containers/basic/{{ item.os.distro }}-{{ item.os.version }}-{{ item.mpi.implementation }}-{{ item.mpi.version }}.sif \
+            {{ playbook_dir }}/basic/{{ item.mpi.implementation }}.def
         else
-          echo "Container {{ original_dir }}/containers/basic/ubuntu-{{ item.os.version }}-ompi-{{ item.mpi.version }}.sif already exists. Skipping build."
+          echo "Container {{ original_dir }}/containers/basic/{{ item.os.distro }}-{{ item.os.version }}-{{ item.mpi.implementation }}-{{ item.mpi.version }}.sif already exists. Skipping build."
         fi
       loop: "{{ mpi_containers }}"
     - name: Try to get base containers from registry
@@ -80,16 +88,20 @@
       ignore_errors: yes
       when: pull.try_to_pull
     - name: Build base containers if corresponding .sif files don't exist
+      vars:
+        distro: "{{ item.1.os.distro | regex_replace('_', '/') }}"
       shell: |
         if [ ! -f {{ original_dir }}/containers/basic/{{ item.0 }}.sif ]; then
           apptainer build --force \
                 --warn-unused-build-args \
+                --build-arg OS_DISTRO={{ distro }} \
                 --build-arg OS_VERSION={{ item.1.os.version }} \
-                --build-arg OPENFOAM_VERSION={{ item.1.openfoam.version }} \
-                --build-arg OPENFOAM_GIT_REF={{ item.1.openfoam.branch | default('default') }} \
-                --build-arg OPENMPI_VERSION={{ item.1.mpi.version }} \
+                --build-arg MPI_IMPLEMENTATION={{ item.1.mpi.implementation }} \
+                --build-arg MPI_VERSION={{ item.1.mpi.version }} \
+                --build-arg FRAMEWORK_VERSION={{ item.1.framework.version }} \
+                --build-arg FRAMEWORK_GIT_REF={{ item.1.framework.branch | default('default') }} \
                 {{ original_dir }}/containers/basic/{{ item.0 }}.sif \
-                {{ playbook_dir }}/basic/{{ item.1.openfoam.fork }}.def
+                {{ playbook_dir }}/basic/{{ item.1.framework.definition }}.def
         else
           echo "Container {{ original_dir }}/containers/basic/{{ item.0 }}.sif already exists. Skipping build."
         fi
@@ -127,9 +139,9 @@
                 --build-arg CONTAINERS_DIR={{ original_dir }}/containers \
                 --build-arg BASE_CONTAINER={{ item.base_container }} \
                 --build-arg OS_VERSION={{ containers.basic[item.base_container].os.version }} \
-                --build-arg OPENMPI_VERSION={{ containers.basic[item.base_container].mpi.version }} \
-                --build-arg OPENFOAM_VERSION={{ containers.basic[item.base_container].openfoam.version }} \
-                --build-arg OPENFOAM_GIT_REF={{ containers.basic[item.base_container].openfoam.git_ref | default('default') }} \
+                --build-arg MPI_VERSION={{ containers.basic[item.base_container].mpi.version }} \
+                --build-arg FRAMEWORK_VERSION={{ containers.basic[item.base_container].framework.version }} \
+                --build-arg FRAMEWORK_GIT_REF={{ containers.basic[item.base_container].framework.git_ref | default('default') }} \
                 {{ original_dir }}/containers/projects/{{ item.name }}.sif \
                 {{ original_dir }}/{{ item.definition }}
       loop: "{{ projects | list }}"

--- a/build.yaml
+++ b/build.yaml
@@ -88,13 +88,12 @@
       ignore_errors: yes
       when: pull.try_to_pull
     - name: Build base containers if corresponding .sif files don't exist
-      vars:
-        distro: "{{ item.1.os.distro | regex_replace('_', '/') }}"
       shell: |
         if [ ! -f {{ original_dir }}/containers/basic/{{ item.0 }}.sif ]; then
+          cd {{ original_dir }}
           apptainer build --force \
                 --warn-unused-build-args \
-                --build-arg OS_DISTRO={{ distro }} \
+                --build-arg OS_DISTRO={{ item.1.os.distro  }} \
                 --build-arg OS_VERSION={{ item.1.os.version }} \
                 --build-arg MPI_IMPLEMENTATION={{ item.1.mpi.implementation }} \
                 --build-arg MPI_VERSION={{ item.1.mpi.version }} \
@@ -103,7 +102,7 @@
                 {{ original_dir }}/containers/basic/{{ item.0 }}.sif \
                 {{ playbook_dir }}/basic/{{ item.1.framework.definition }}.def
         else
-          echo "Container {{ original_dir }}/containers/basic/{{ item.0 }}.sif already exists. Skipping build."
+          echo "Container {{ original_dir }}/containers/basic/{{ item.1.framework.definition }}.sif already exists. Skipping build."
         fi
       loop: "{{ containers.basic.items() }}"
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,18 +1,32 @@
 # containers section defines what containers to build
 containers:
+  # This is either a local path, or a Git repo URI
+  # to load your own basic definition files; they can then be used in framework.definition below
+  #extra_basics: /tmp/extrabasics
   # This section builds base containers in containers/basic
   basic:
     # you get opencfd-openfoam.sif and openmpi-4.1.5-ubuntu-24.04.sif from the following entry
-    opencfd-openfoam: # base container identifier
+    lammps: # base container identifier
       os:
         distro: ubuntu # the only supported distro atm
         version: 24.04 # needs to be recent
       mpi:
-        implementation: openmpi # the only supported MPI implementation atm
+        implementation: openmpi # there must be a openmpi.def in basic/ folder
         version: 4.1.5 # recommended to match host MPI at least in major version number
-      openfoam:
-        fork: com-openfoam # org-openfoam, and foam-extend also supported
-        version: 2312 # specific version number for the target fork
+      framework:
+        definition: lammps # org-openfoam, and foam-extend also supported, see basic/
+        version: patch_27Jun2024 # specific version number for the target fork
+    # you get foam-extend.sif from the following entry
+    #opencfd-openfoam: # base container identifier
+    #  os:
+    #    distro: ubuntu # the only supported distro atm for this specific combination of settings
+    #    version: 24.04 # needs to be recent
+    #  mpi:
+    #    implementation: openmpi # there must be a openmpi.def in basic/ folder
+    #    version: 4.1.5 # recommended to match host MPI at least in major version number
+    #  framework:
+    #    definition: com-openfoam # org-openfoam, and foam-extend also supported, see basic/
+    #    version: 2312 # specific version number for the target fork
     # you get foam-extend.sif from the following entry
     #foam-extend:
     #  os:
@@ -26,15 +40,15 @@ containers:
     #    version: 5.0
     #    git_ref: master # optional (default: default)
   # This section builds final containers in containers/projects
-  projects:
-    # you get test-master.sif and test-dev.sif from the following entry
-    test:
-      base_container: opencfd-openfoam # what base container to build the project against (from containers.basic above)
-      definition: projects/test.def # path to container definition file (relative to CWD)
-      build_args: # case-insensitive, optional build arguments for apptainer
-        branch:
-          - master  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
-          #- dev  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
+  #projects:
+  #  # you get test-master.sif and test-dev.sif from the following entry
+  #  test:
+  #    base_container: opencfd-openfoam # what base container to build the project against (from containers.basic above)
+  #    definition: projects/test.def # path to container definition file (relative to CWD)
+  #    build_args: # case-insensitive, optional build arguments for apptainer
+  #      branch:
+  #        - master  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
+  #        #- dev  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
     # you get extend-test.sif from the following entry
     #extend-test:
     #  base_container: foam-extend
@@ -42,6 +56,6 @@ containers:
 
 # pull section sets pull paramters
 pull:
-  try_to_pull: true # Do we try to pull from registry?
+  try_to_pull: false # Do we try to pull from registry?
   protocol: "oras" # docker, or library as Pull protocol
   scope: "ghcr.io/foamscience" # so oras://ghcr.io/foamscience/<container-name>:latest is used

--- a/config.yaml
+++ b/config.yaml
@@ -1,32 +1,23 @@
 # containers section defines what containers to build
 containers:
+
   # This is either a local path, or a Git repo URI
   # to load your own basic definition files; they can then be used in framework.definition below
   #extra_basics: /tmp/extrabasics
+  
   # This section builds base containers in containers/basic
   basic:
     # you get opencfd-openfoam.sif and openmpi-4.1.5-ubuntu-24.04.sif from the following entry
-    lammps: # base container identifier
+    opencfd-openfoam: # base container identifier
       os:
-        distro: ubuntu # the only supported distro atm
+        distro: ubuntu # the only supported distro atm for this specific combination of settings
         version: 24.04 # needs to be recent
       mpi:
-        implementation: openmpi # there must be a openmpi.def in basic/ folder
+        implementation: openmpi # there must be an openmpi.def in basic/ folder
         version: 4.1.5 # recommended to match host MPI at least in major version number
       framework:
-        definition: lammps # org-openfoam, and foam-extend also supported, see basic/
-        version: patch_27Jun2024 # specific version number for the target fork
-    # you get foam-extend.sif from the following entry
-    #opencfd-openfoam: # base container identifier
-    #  os:
-    #    distro: ubuntu # the only supported distro atm for this specific combination of settings
-    #    version: 24.04 # needs to be recent
-    #  mpi:
-    #    implementation: openmpi # there must be a openmpi.def in basic/ folder
-    #    version: 4.1.5 # recommended to match host MPI at least in major version number
-    #  framework:
-    #    definition: com-openfoam # org-openfoam, and foam-extend also supported, see basic/
-    #    version: 2312 # specific version number for the target fork
+        definition: com-openfoam # org-openfoam, and foam-extend also supported, see basic/ for more
+        version: 2312 # specific version number for the target fork
     # you get foam-extend.sif from the following entry
     #foam-extend:
     #  os:
@@ -40,15 +31,15 @@ containers:
     #    version: 5.0
     #    git_ref: master # optional (default: default)
   # This section builds final containers in containers/projects
-  #projects:
-  #  # you get test-master.sif and test-dev.sif from the following entry
-  #  test:
-  #    base_container: opencfd-openfoam # what base container to build the project against (from containers.basic above)
-  #    definition: projects/test.def # path to container definition file (relative to CWD)
-  #    build_args: # case-insensitive, optional build arguments for apptainer
-  #      branch:
-  #        - master  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
-  #        #- dev  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
+  projects:
+    # you get test-master.sif and test-dev.sif from the following entry
+    test:
+      base_container: opencfd-openfoam # what base container to build the project against (from containers.basic above)
+      definition: projects/test.def # path to container definition file (relative to CWD)
+      build_args: # case-insensitive, optional build arguments for apptainer
+        branch:
+          - master  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
+          #- dev  # will be passed as `--build-arg BRANCH=master` to `apptainer build`
     # you get extend-test.sif from the following entry
     #extend-test:
     #  base_container: foam-extend
@@ -56,6 +47,6 @@ containers:
 
 # pull section sets pull paramters
 pull:
-  try_to_pull: false # Do we try to pull from registry?
+  try_to_pull: true # Do we try to pull from registry?
   protocol: "oras" # docker, or library as Pull protocol
   scope: "ghcr.io/foamscience" # so oras://ghcr.io/foamscience/<container-name>:latest is used

--- a/docs.md
+++ b/docs.md
@@ -221,7 +221,10 @@ definition files for basic containers. These definitions will then be usable as
 `containers.basic.<container-name>.framework.definition`
 and even `containers.basic.<container-name>.mpi.implementation`.
 
-As an example, let's consider using `spack` containers instead.
+The  [spack-apptainer-containers](https://github.com/FoamScience/spack-apptainer-containers)
+repository demonstrates how custom base images can be used to build spack-powered containers
+
+
 In `/tmp/spack_containers/basic/spack_openmpi.def` you can have:
 ```
 Bootstrap: docker
@@ -233,21 +236,24 @@ From: {{ OS_DISTRO }}:{{ OS_VERSION }}
     . /opt/spack/share/spack/setup-env.sh
     # MPI_IMPLEMENTATION will be "spack_openmpi" as specified in the config
     mpi_impl=$(expr "{{ MPI_IMPLEMENTATION }}" : 'spack_\(.*\)')
-    spack install $mpi_impl@{{ MPI_VERSION }} jq
+    spack install ${mpi_impl}@{{ MPI_VERSION }} jq
 ```
 > `/tmp/spack_containers/basic/spack_openfoam.def` is also very similar
-> but must base itself off of the generated MPI container. A full implementation
-> of this experiment is provided at [spack-apptainer-containers](https://github.com/FoamScience/spack-apptainer-containers)
+> but must base itself off of the generated MPI container. Look at
+> [spack-apptainer-containers](https://github.com/FoamScience/spack-apptainer-containers)
+> for an example implementation
 
 And the basic container in `config.yaml` can look like this:
 ```yaml
 containers:
-  extra_basics: /tmp/spack_containers
+  extra_basics: https://github.com/FoamScience/spack-apptainer-containers
   basic:
-    spack_openfoam:
+    spack_openfoam: # you get containers/basic/spack_openfoam.sif
       os:
         distro: spack_ubuntu-bionic # the underscore will be converted to / inside the definition files
                 # so this bases the container off the spack/ubuntu-bionic:latest docker image
+                # To build on top of setup, change this to spack_centos7
+                # BUT this may not always work, an experimental feature at best
         version: latest
       mpi:
         implementation: spack_openmpi # looks for spack_openmpi.def in basic folder

--- a/docs.md
+++ b/docs.md
@@ -232,12 +232,12 @@ From: {{ OS_DISTRO }}:{{ OS_VERSION }}
 %post
     . /opt/spack/share/spack/setup-env.sh
     # MPI_IMPLEMENTATION will be "spack_openmpi" as specified in the config
-    mpi_impl="${{{ MPI_IMPLEMENTATION }}#spack_}"
-    spack install $mpi_impl@{{ MPI_VERSION }}
+    mpi_impl=$(expr "{{ MPI_IMPLEMENTATION }}" : 'spack_\(.*\)')
+    spack install $mpi_impl@{{ MPI_VERSION }} jq
 ```
 > `/tmp/spack_containers/basic/spack_openfoam.def` is also very similar
-> but must base itself off of the generated MPI container. See original `basic`
-> folder for inspiration.
+> but must base itself off of the generated MPI container. A full implementation
+> of this experiment is provided at [spack-apptainer-containers](https://github.com/FoamScience/spack-apptainer-containers)
 
 And the basic container in `config.yaml` can look like this:
 ```yaml

--- a/docs.md
+++ b/docs.md
@@ -1,4 +1,9 @@
-## Build OpenFOAM apptainer containers
+> We take OpenFOAM as an example here, but containers for any other HPC software
+> package can be built in the same way.
+
+## Build apptainer containers for OpenFOAM 
+
+You only need to:
 
 1. Supply a configuration file (look at [config.yaml](config.yaml) for an example)
 2. Run the build playbook and point to the configuration:
@@ -20,8 +25,8 @@ containers:
       mpi:
         implementation: openmpi 
         version: 4.1.5 
-      openfoam:
-        fork: com-openfoam 
+      framework:
+        definition: com-openfoam 
         version: 2312 
 ```
 
@@ -31,7 +36,7 @@ will try to pull some base containers from a registry, and build them only if th
 unsuccessful. Pull-related behaviour can be configured in a `pull` section
 (again, refer to [config.yaml](config.yaml) for an example).
 
-## Build containers for your OpenFOAM projects
+## Build containers for your OpenFOAM-based projects
 
 1. Add your project to the configuration file.
 2. Write a [definition file](https://apptainer.org/docs/user/main/definition_files.html) for your project.
@@ -49,8 +54,8 @@ containers:
       mpi:
         implementation: openmpi
         version: 4.1.5
-      openfoam:
-        fork: com-openfoam
+      framework:
+        definition: com-openfoam
         version: 2312
   projects:
     test:
@@ -75,20 +80,23 @@ definition file. It will be replaced with the possible values of `build_args.bra
 
 The definition files should also follow a set of rules:
 
-- The bootstrapping should be set to `localimage`, and the appropriate build arguments should be used as follows:
+- The bootstrapping should be set to `localimage`,
+  and the appropriate build arguments should be used as follows:
 ```bash
 Bootstrap: localimage
 From: {{ CONTAINERS_DIR }}/basic/{{ BASE_CONTAINER }}.sif
 ```
-- Even though the build argument for base images will be passed on the command line; it's recommended
-  to give default values for them in the definition file anyway
+- Even though the build argument for base images will be passed on the command line;
+  it's recommended to give default values for them in the definition file anyway
 ```bash
 %arguments
     BASE_CONTAINER=opencfd-openfoam
+    OS_DISTRO=ubuntu
     OS_VERSION=24.04
-    OPENMPI_VERSION=4.1.5
-    OPENFOAM_VERSION=2312
-    OPENFOAM_GIT_REF=default
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
+    FRAMEWORK_VERSION=2312
+    FRAMEWORK_GIT_REF=default
 ```
 - In the definition file, important metadata about the container should be logged to `/apps.json`. Refer to
   the [projects/test.def](projects/test.def) example for inspiration.
@@ -204,3 +212,56 @@ docker scout quickview fs://ubuntu-24.04-ompi-4.1.5
 # of most of the vulnerabilities
 docker scout cves fs://ubuntu-24.04-ompi-4.1.5
 ```
+
+## Load your own base containers
+
+The `config.yaml` file can take a `containers.extra_basics` entry, which can be either a
+git URI or a local path to a folder containing a `basic` subfolder which hosts your custom
+definition files for basic containers. These definitions will then be usable as
+`containers.basic.<container-name>.framework.definition`
+and even `containers.basic.<container-name>.mpi.implementation`.
+
+As an example, let's consider using `spack` containers instead.
+In `/tmp/spack_containers/basic/spack_openmpi.def` you can have:
+```
+Bootstrap: docker
+From: {{ OS_DISTRO }}:{{ OS_VERSION }}
+# This will expand to
+# From: spack/ubuntu-bionic:latest
+
+%post
+    . /opt/spack/share/spack/setup-env.sh
+    # MPI_IMPLEMENTATION will be "spack_openmpi" as specified in the config
+    mpi_impl="${{{ MPI_IMPLEMENTATION }}#spack_}"
+    spack install $mpi_impl@{{ MPI_VERSION }}
+```
+> `/tmp/spack_containers/basic/spack_openfoam.def` is also very similar
+> but must base itself off of the generated MPI container. See original `basic`
+> folder for inspiration.
+
+And the basic container in `config.yaml` can look like this:
+```yaml
+containers:
+  extra_basics: /tmp/spack_containers
+  basic:
+    spack_openfoam:
+      os:
+        distro: spack_ubuntu-bionic # the underscore will be converted to / inside the definition files
+                # so this bases the container off the spack/ubuntu-bionic:latest docker image
+        version: latest
+      mpi:
+        implementation: spack_openmpi # looks for spack_openmpi.def in basic folder
+        version: 4.1.5
+      framework:
+        definition: spack_openfoam # looks for spack_openfoam.def in basic folder
+        version: 2312
+```
+
+It's important to understand that the ansible playbook will always generate containers with MPI support
+as a first layer, then generate the basic framework container on top of that.
+
+> [!IMPORTANT]
+> Although definition files leveraging `spack` will be generally shorter and easier to maintain, the resulting
+> containers will be much larger than using distribution package managers. Also, at the time of writing,
+> `spack` doesn't allow for easy switching of the underlying distribution as random installation errors
+> arise for the same definition file if you base it on ubuntu and centos 7 images.

--- a/partials/include_extra_basics.yaml
+++ b/partials/include_extra_basics.yaml
@@ -1,0 +1,17 @@
+---
+- name: Determine if the extra_basics path is a URL
+  set_fact:
+    is_basics_url: "{{ containers.extra_basics | regex_search('^(http|https|git|ssh)://') is not none }}"
+- name: Clone git repository if extras is a URL
+  git:
+    repo: "{{ source_path }}"
+    dest: "/tmp/extra_basic_defs"
+  when: is_basics_url
+- name: Copy extra basic definition files from repo to @build folder
+  shell: |
+    find /tmp/extra_basic_defs/basic -type f -name '*def' -exec cp {} ./basic/ \;
+  when: is_basics_url
+- name: Copy local extra basic definition files to @build folder
+  shell: |
+    find {{ containers.extra_basics }}/basic -type f -name '*def' -exec cp {} ./basic/ \;
+  when: not is_basics_url

--- a/projects/test.def
+++ b/projects/test.def
@@ -14,10 +14,12 @@ From: {{ CONTAINERS_DIR }}/basic/{{ BASE_CONTAINER }}.sif
 
 %arguments
     BASE_CONTAINER=opencfd-openfoam
+    OS_DISTRO=ubuntu
     OS_VERSION=24.04
-    OPENMPI_VERSION=4.1.5
-    OPENFOAM_VERSION=2312
-    OPENFOAM_GIT_REF=default
+    MPI_IMPLEMENTATION=openmpi
+    MPI_VERSION=4.1.5
+    FRAMEWORK_VERSION=2312
+    FRAMEWORK_GIT_REF=default
 
 %files
     OMPIFoam /opt/OMPIFoam
@@ -25,7 +27,7 @@ From: {{ CONTAINERS_DIR }}/basic/{{ BASE_CONTAINER }}.sif
 %post
     echo "Testing OpenMPI implementation"
     /bin/bash -c "cd /opt/OMPIFoam && mpicc -o ompiTest testOMPI.cpp"
-    /bin/bash -c "source /usr/lib/openfoam/openfoam{{ OPENFOAM_VERSION }}/etc/bashrc && cd /opt/OMPIFoam && wmake"
+    /bin/bash -c "source /usr/lib/openfoam/openfoam{{ FRAMEWORK_VERSION }}/etc/bashrc && cd /opt/OMPIFoam && wmake"
     jq --arg app test --arg branch {{ BRANCH }} \
         '.[$app] |= if . == null then
         {


### PR DESCRIPTION
This PR introduces two important, but inter-connected features:
1. Users can now build containers for arbitrary software packages if the can write definition files for them
2. The ansible playbook with load user-defined base container definitions from a specified repo/path

Goals:
- Allow users to keep repositories of important base containers without bloating this repository.

**Example usage:** [Experimenting with spack to provide distribution-agnostic definition files](https://github.com/FoamScience/spack-apptainer-containers). Ideally, with this repository, users only need to change `containers.basic.opencfd-openfoam.os.distro` to `spack_centos7` for centOS-based containers instead of Ubuntu (default).
This has potential, but not perfect yet. 