### PR TITLE
Add runscript to test.def to source OpenFOAM automatically

### DIFF
--- a/projects/test.def
+++ b/projects/test.def
@@ -44,5 +44,13 @@ From: {{ CONTAINERS_DIR }}/basic/{{ BASE_CONTAINER }}.sif
         } end' /apps.json > /tmp/apps.json
     mv /tmp/apps.json /apps.json
 
+%runscript
+    /bin/bash -c 'cd /usr/lib/openfoam/openfoam{{ FRAMEWORK_VERSION }} && source etc/bashrc && mkdir -p $FOAM_USER_LIBBIN && mkdir -p $FOAM_USER_APPBIN'
+    if [ $# -eq 0 ]; then
+        /usr/bin/openfoam{{ FRAMEWORK_VERSION }}
+    else
+        /usr/bin/openfoam{{ FRAMEWORK_VERSION }} $@
+    fi
+
 %labels
     Description Test applications for ESI OpenFOAM


### PR DESCRIPTION
Fixes #6

Add a `%runscript` section to `projects/test.def` to source OpenFOAM automatically.

* Add a `%runscript` section to `projects/test.def` to source OpenFOAM automatically.
* Use the `%runscript` section from `basic/com-openfoam.def` as a reference.
* Ensure the `%runscript` section sets up user directories.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FoamScience/openfoam-apptainer-packaging/issues/6?shareId=56a9278b-459a-44d0-9f6f-9c3ab664139a).